### PR TITLE
Add bodyParser.urlencoded middleware

### DIFF
--- a/back/core/express/core.express.js
+++ b/back/core/express/core.express.js
@@ -78,6 +78,7 @@ ExpressApp.prototype.init = BPromise.method(function(opts) {
     this.app.set('x-powered-by', false);
 
     this.app.use(cookieParser());
+    this.app.use(bodyParser.urlencoded({extended: false}));
     this.app.use(bodyParser.json());
 
     // Init websockets


### PR DESCRIPTION
I think this fixes issue #10.

The problem was that the bodyParser.urlencoded middleware wasn't included
so the registration form wasn't being parsed and the req.body variable was empty.
